### PR TITLE
Add Weltfrauentag as holiday in Berlin

### DIFF
--- a/german-holidays.html
+++ b/german-holidays.html
@@ -480,8 +480,8 @@
                     namerAlt: 'International Women\'s Day',
                     month: 3,
                     day: 8,
-                    regions: [],
-                    character: characteristic.actionday
+                    regions: ['BE'],
+                    character: characteristic.holiday
                 },
                 PALMSONNTAG: {
                     name: 'Palmsonntag', // 7 Tage vor dem Ostersonntag
@@ -531,13 +531,6 @@
                     day: 1,
                     regions: [],
                     character: characteristic.calendar
-                },
-                FRAUENTAG: {
-                    name: 'Frauentag', // 8. März - Internationaler Frauentag
-                    month: 3,
-                    day: 8,
-                    regions: [],
-                    character: characteristic.actionday
                 },
                 APRILSCHERZ: {
                     name: '1. April',


### PR DESCRIPTION
In addition deleted double entry for Frauentag. See issue #19.